### PR TITLE
chore: update README to replace Drizzle with Prisma

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you are not familiar with the different technologies used in this project, pl
 
 - [Next.js](https://nextjs.org)
 - [Better Auth](https://better-auth.com)
-- [Drizzle](https://orm.drizzle.team)
+- [Prisma](https://www.prisma.io/)
 - [Tailwind CSS](https://tailwindcss.com)
 - [tRPC](https://trpc.io)
 


### PR DESCRIPTION
This pull request includes a small update to the `README.md` file. The change replaces the reference to Drizzle with a reference to Prisma in the list of technologies used in the project.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R11): Replaced Drizzle with Prisma in the list of technologies.